### PR TITLE
Auto-reload on file change with dismissable notification

### DIFF
--- a/MarkdownViewer/ViewModels/DocumentState.swift
+++ b/MarkdownViewer/ViewModels/DocumentState.swift
@@ -2,6 +2,7 @@ import Combine
 import CoreGraphics
 import Foundation
 import Markdown
+import SwiftUI
 
 class DocumentState: ObservableObject {
     @Published var htmlContent: String = ""
@@ -134,7 +135,9 @@ class DocumentState: ObservableObject {
             guard let self = self else { return }
             let newModDate = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
             if newModDate != self.lastModificationDate {
-                self.fileChanged = true
+                self.lastModificationDate = newModDate
+                self.reload()
+                withAnimation(.easeInOut(duration: 0.2)) { self.fileChanged = true }
             }
         }
 

--- a/MarkdownViewer/Views/ContentView.swift
+++ b/MarkdownViewer/Views/ContentView.swift
@@ -80,7 +80,9 @@ struct ContentView: View {
             }
         }
         .onExitCommand {
-            if documentState.isShowingFindBar {
+            if documentState.fileChanged {
+                withAnimation(.easeInOut(duration: 0.2)) { documentState.fileChanged = false }
+            } else if documentState.isShowingFindBar {
                 documentState.hideFindBar()
             }
         }
@@ -110,22 +112,24 @@ struct ContentView: View {
             if documentState.fileChanged || documentState.isShowingFindBar {
                 VStack(alignment: .trailing, spacing: 8) {
                     if documentState.fileChanged {
-                        Button(action: {
-                            documentState.reload()
-                        }) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.system(size: 11, weight: .medium))
-                                Text("File changed")
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(Color.orange.opacity(0.9))
-                            .foregroundColor(.white)
-                            .cornerRadius(6)
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .font(.system(size: 11, weight: .medium))
+                            Text("File updated")
+                                .font(.system(size: 11, weight: .medium))
+                            Text("esc to dismiss")
+                                .font(.system(size: 10))
+                                .opacity(0.7)
                         }
-                        .buttonStyle(.plain)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Color.accentColor.opacity(0.85))
+                        .foregroundColor(.white)
+                        .cornerRadius(6)
+                        .onTapGesture {
+                            withAnimation(.easeInOut(duration: 0.2)) { documentState.fileChanged = false }
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
                     }
 
                     if documentState.isShowingFindBar {


### PR DESCRIPTION
## Summary
- Replaces the blocking "File changed" banner (which required clicking to reload) with automatic reload on file change
- Shows a dismissable "File updated" notice so users are aware content was refreshed
- Notice dismisses via click, Escape key, and animates in/out with a fade+slide transition

Companion to #13 — as noted in that PR's follow-up section — but independent and submitted against `main`.

## Details

- **DocumentState**: File monitor now calls `reload()` immediately on detecting a change, and sets `fileChanged` for the notification badge
- **ContentView**: Replaces the orange click-to-reload button with a blue informational badge ("File updated · esc to dismiss")
- Transition uses `withAnimation` for smooth appear/disappear

## How to test
- [ ] Open a `.md` file in the viewer
- [ ] Edit the same file in any external editor and save
- [ ] Verify the viewer auto-reloads with updated content
- [ ] Verify the blue "File updated · esc to dismiss" badge appears (top-right)
- [ ] Verify clicking the badge dismisses it (with animation)
- [ ] Verify pressing Escape dismisses it (with animation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)