### PR TITLE
Add optional bring-to-front on file change

### DIFF
--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct MarkdownViewerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var recentFilesStore = RecentFilesStore.shared
+    @AppStorage("autoRaiseOnFileChange") private var autoRaiseOnFileChange = false
 
     var body: some Scene {
         WindowGroup {
@@ -95,6 +96,10 @@ struct MarkdownViewerApp: App {
                     appDelegate.resetZoom()
                 }
                 .keyboardShortcut("0", modifiers: .command)
+
+                Divider()
+
+                Toggle("Bring to Front on File Change", isOn: $autoRaiseOnFileChange)
             }
         }
     }

--- a/MarkdownViewer/ViewModels/DocumentState.swift
+++ b/MarkdownViewer/ViewModels/DocumentState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import CoreGraphics
 import Foundation
@@ -135,6 +136,9 @@ class DocumentState: ObservableObject {
             let newModDate = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
             if newModDate != self.lastModificationDate {
                 self.fileChanged = true
+                if UserDefaults.standard.bool(forKey: "autoRaiseOnFileChange") {
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Adds a View menu toggle ("Bring to Front on File Change") that raises the viewer window when the monitored file is modified externally
- Off by default — opt-in behavior
- Minimal change: 2 files, 9 lines added

## Details
- **DocumentState**: Checks UserDefaults in the file monitor event handler and calls `NSApplication.shared.activate(ignoringOtherApps: true)` when enabled
- **MarkdownViewerApp**: Adds an `@AppStorage`-backed toggle under View > Zoom controls

## Note
If #13 is also merged, this toggle can be consolidated into the Settings modal for a cleaner UI. As a standalone, the View menu toggle is fully self-contained.

Companion to #13 — as noted in that PR's follow-up section — but independent and submitted against `main`.

## How to test
- [ ] Open a `.md` file in the viewer
- [ ] Enable View > Bring to Front on File Change
- [ ] Switch to another app, edit the file externally and save
- [ ] Verify the viewer window comes to front
- [ ] Disable the toggle, repeat — viewer should stay in background
- [ ] Verify the setting persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)