### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2026-02-05
-- Configurable external editor: choose your preferred editor and keyboard shortcut via Settings (Cmd+,). Defaults to system default app with Cmd+E.
+- Configurable external editor: choose your preferred editor and keyboard shortcut via Settings (Cmd+,). Prompts to choose an editor on first use. Default shortcut: Cmd+E.
 
 ## 2026-01-29
 - Added Mermaid rendering via Beautiful Mermaid (thanks [@zalun](https://github.com/zalun) for PR #11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 2026-02-05
+- Configurable external editor: choose your preferred editor and keyboard shortcut via Settings (Cmd+,). Defaults to system default app with Cmd+E.
+
 ## 2026-01-29
 - Added Mermaid rendering via Beautiful Mermaid (thanks [@zalun](https://github.com/zalun) for PR #11).

--- a/MarkdownViewer/App/AppDelegate.swift
+++ b/MarkdownViewer/App/AppDelegate.swift
@@ -35,8 +35,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return event }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
-            // External editor shortcut (configurable)
+            // External editor shortcut (configurable, only when a document window is active)
             if self.eventMatchesEditorShortcut(flags: flags, event: event) {
+                guard self.activeDocumentWindow() != nil else { return event }
                 self.openInExternalEditor()
                 return nil
             }

--- a/MarkdownViewer/App/AppDelegate.swift
+++ b/MarkdownViewer/App/AppDelegate.swift
@@ -132,6 +132,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         activeDocumentState()?.findPrevious()
     }
 
+    func openInExternalEditor() {
+        guard let url = activeDocumentState()?.currentURL else {
+            NSSound.beep()
+            return
+        }
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: URL(fileURLWithPath: "/Applications/Sublime Text.app"),
+            configuration: NSWorkspace.OpenConfiguration()
+        )
+    }
+
     func selectNextTab() {
         activeDocumentWindow()?.selectNextTab(nil)
     }

--- a/MarkdownViewer/App/AppDelegate.swift
+++ b/MarkdownViewer/App/AppDelegate.swift
@@ -162,16 +162,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func promptForEditor(thenOpen fileURL: URL) {
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.applicationBundle]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.directoryURL = URL(fileURLWithPath: "/Applications")
-        panel.message = "Choose an editor application for Markdown files"
-        panel.prompt = "Choose"
-
-        guard panel.runModal() == .OK, let editorURL = panel.url else { return }
+        guard let editorURL = ExternalEditorSettings.presentEditorChooserPanel(
+            message: "Choose an editor application for Markdown files"
+        ) else { return }
         ExternalEditorSettings.shared.setEditor(url: editorURL)
         NSWorkspace.shared.open(
             [fileURL],

--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -5,6 +5,7 @@ struct MarkdownViewerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var recentFilesStore = RecentFilesStore.shared
     @ObservedObject private var editorSettings = ExternalEditorSettings.shared
+    @ObservedObject private var appearanceSettings = AppearanceSettings.shared
     @AppStorage("autoRaiseOnFileChange") private var autoRaiseOnFileChange = false
 
     var body: some Scene {
@@ -89,6 +90,13 @@ struct MarkdownViewerApp: App {
                 }
             }
             CommandGroup(after: .toolbar) {
+                Button(appearanceSettings.label) {
+                    appearanceSettings.cycle()
+                }
+                .keyboardShortcut("l", modifiers: [.command, .shift])
+
+                Divider()
+
                 Button("Zoom In") {
                     appDelegate.zoomIn()
                 }

--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -79,6 +79,13 @@ struct MarkdownViewerApp: App {
                     appDelegate.findPrevious()
                 }
                 .keyboardShortcut("g", modifiers: [.command, .shift])
+
+                Divider()
+
+                Button("Open in Sublime Text") {
+                    appDelegate.openInExternalEditor()
+                }
+                .keyboardShortcut("e", modifiers: .command)
             }
             CommandGroup(after: .toolbar) {
                 Button("Zoom In") {

--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -83,16 +83,8 @@ struct MarkdownViewerApp: App {
 
                 Divider()
 
-                if let shortcut = editorSettings.keyboardShortcut {
-                    Button(editorSettings.menuItemTitle) {
-                        appDelegate.openInExternalEditor()
-                    }
-                    .keyboardShortcut(shortcut)
-                    .id(editorSettings.shortcutIdentity)
-                } else {
-                    Button(editorSettings.menuItemTitle) {
-                        appDelegate.openInExternalEditor()
-                    }
+                Button(editorSettings.menuItemTitle) {
+                    appDelegate.openInExternalEditor()
                 }
             }
             CommandGroup(after: .toolbar) {

--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct MarkdownViewerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var recentFilesStore = RecentFilesStore.shared
+    @ObservedObject private var editorSettings = ExternalEditorSettings.shared
 
     var body: some Scene {
         WindowGroup {
@@ -82,10 +83,17 @@ struct MarkdownViewerApp: App {
 
                 Divider()
 
-                Button("Open in Sublime Text") {
-                    appDelegate.openInExternalEditor()
+                if let shortcut = editorSettings.keyboardShortcut {
+                    Button(editorSettings.menuItemTitle) {
+                        appDelegate.openInExternalEditor()
+                    }
+                    .keyboardShortcut(shortcut)
+                    .id(editorSettings.shortcutIdentity)
+                } else {
+                    Button(editorSettings.menuItemTitle) {
+                        appDelegate.openInExternalEditor()
+                    }
                 }
-                .keyboardShortcut("e", modifiers: .command)
             }
             CommandGroup(after: .toolbar) {
                 Button("Zoom In") {
@@ -103,6 +111,9 @@ struct MarkdownViewerApp: App {
                 }
                 .keyboardShortcut("0", modifiers: .command)
             }
+        }
+        Settings {
+            SettingsView()
         }
     }
 }

--- a/MarkdownViewer/App/MarkdownViewerApp.swift
+++ b/MarkdownViewer/App/MarkdownViewerApp.swift
@@ -5,6 +5,7 @@ struct MarkdownViewerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var recentFilesStore = RecentFilesStore.shared
     @ObservedObject private var editorSettings = ExternalEditorSettings.shared
+    @AppStorage("autoRaiseOnFileChange") private var autoRaiseOnFileChange = false
 
     var body: some Scene {
         WindowGroup {
@@ -102,6 +103,10 @@ struct MarkdownViewerApp: App {
                     appDelegate.resetZoom()
                 }
                 .keyboardShortcut("0", modifiers: .command)
+
+                Divider()
+
+                Toggle("Bring to Front on File Change", isOn: $autoRaiseOnFileChange)
             }
         }
         Settings {

--- a/MarkdownViewer/Stores/AppearanceSettings.swift
+++ b/MarkdownViewer/Stores/AppearanceSettings.swift
@@ -24,7 +24,10 @@ final class AppearanceSettings: ObservableObject {
         let raw = UserDefaults.standard.integer(forKey: "appearanceMode")
         mode = AppearanceMode(rawValue: raw) ?? .system
         isLoading = false
-        applyAppearance()
+        // NSApp may be nil during early init; defer until the app is ready
+        DispatchQueue.main.async { [self] in
+            applyAppearance()
+        }
     }
 
     func cycle() {
@@ -52,13 +55,14 @@ final class AppearanceSettings: ObservableObject {
     }
 
     private func applyAppearance() {
+        guard let app = NSApp else { return }
         switch mode {
         case .system:
-            NSApp.appearance = nil
+            app.appearance = nil
         case .light:
-            NSApp.appearance = NSAppearance(named: .aqua)
+            app.appearance = NSAppearance(named: .aqua)
         case .dark:
-            NSApp.appearance = NSAppearance(named: .darkAqua)
+            app.appearance = NSAppearance(named: .darkAqua)
         }
     }
 }

--- a/MarkdownViewer/Stores/AppearanceSettings.swift
+++ b/MarkdownViewer/Stores/AppearanceSettings.swift
@@ -1,0 +1,64 @@
+import AppKit
+
+enum AppearanceMode: Int {
+    case system = 0
+    case light = 1
+    case dark = 2
+}
+
+final class AppearanceSettings: ObservableObject {
+    static let shared = AppearanceSettings()
+
+    @Published var mode: AppearanceMode = .system {
+        didSet {
+            guard !isLoading else { return }
+            UserDefaults.standard.set(mode.rawValue, forKey: "appearanceMode")
+            applyAppearance()
+        }
+    }
+
+    private var isLoading = false
+
+    private init() {
+        isLoading = true
+        let raw = UserDefaults.standard.integer(forKey: "appearanceMode")
+        mode = AppearanceMode(rawValue: raw) ?? .system
+        isLoading = false
+        applyAppearance()
+    }
+
+    func cycle() {
+        switch mode {
+        case .system: mode = .light
+        case .light: mode = .dark
+        case .dark: mode = .system
+        }
+    }
+
+    var iconName: String {
+        switch mode {
+        case .system: return "circle.lefthalf.filled"
+        case .light: return "sun.max.fill"
+        case .dark: return "moon.fill"
+        }
+    }
+
+    var label: String {
+        switch mode {
+        case .system: return "Appearance: System"
+        case .light: return "Appearance: Light"
+        case .dark: return "Appearance: Dark"
+        }
+    }
+
+    private func applyAppearance() {
+        switch mode {
+        case .system:
+            NSApp.appearance = nil
+        case .light:
+            NSApp.appearance = NSAppearance(named: .aqua)
+        case .dark:
+            NSApp.appearance = NSAppearance(named: .darkAqua)
+        }
+    }
+}

--- a/MarkdownViewer/Stores/ExternalEditorSettings.swift
+++ b/MarkdownViewer/Stores/ExternalEditorSettings.swift
@@ -1,0 +1,119 @@
+import Combine
+import Foundation
+import SwiftUI
+
+final class ExternalEditorSettings: ObservableObject {
+    static let shared = ExternalEditorSettings()
+
+    @Published var editorAppURL: URL? {
+        didSet { save() }
+    }
+    @Published var editorDisplayName: String = "External Editor" {
+        didSet { save() }
+    }
+    @Published var shortcutKey: String = "e" {
+        didSet { save() }
+    }
+    @Published var shortcutModifiers: UInt = NSEvent.ModifierFlags.command.rawValue {
+        didSet { save() }
+    }
+
+    var menuItemTitle: String {
+        if editorAppURL != nil {
+            return "Open in \(editorDisplayName)"
+        }
+        return "Open in External Editor"
+    }
+
+    var keyboardShortcut: KeyboardShortcut? {
+        guard let char = shortcutKey.lowercased().first else { return nil }
+        let flags = NSEvent.ModifierFlags(rawValue: shortcutModifiers)
+        var modifiers: EventModifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        return KeyboardShortcut(KeyEquivalent(char), modifiers: modifiers)
+    }
+
+    var shortcutIdentity: String {
+        "\(shortcutKey)-\(shortcutModifiers)"
+    }
+
+    var shortcutDisplayString: String {
+        let flags = NSEvent.ModifierFlags(rawValue: shortcutModifiers)
+        var parts: [String] = []
+        if flags.contains(.control) { parts.append("\u{2303}") }
+        if flags.contains(.option) { parts.append("\u{2325}") }
+        if flags.contains(.shift) { parts.append("\u{21E7}") }
+        if flags.contains(.command) { parts.append("\u{2318}") }
+        parts.append(shortcutKey.uppercased())
+        return parts.joined()
+    }
+
+    var editorIcon: NSImage? {
+        guard let url = editorAppURL else { return nil }
+        return NSWorkspace.shared.icon(forFile: url.path)
+    }
+
+    private let defaults = UserDefaults.standard
+    private let editorAppURLKey = "externalEditorAppURL"
+    private let editorDisplayNameKey = "externalEditorDisplayName"
+    private let shortcutKeyKey = "externalEditorShortcutKey"
+    private let shortcutModifiersKey = "externalEditorShortcutModifiers"
+
+    private init() {
+        load()
+    }
+
+    func setEditor(url: URL) {
+        editorAppURL = url
+        editorDisplayName = Self.displayName(for: url)
+    }
+
+    func clearEditor() {
+        editorAppURL = nil
+        editorDisplayName = "External Editor"
+    }
+
+    func setShortcut(key: String, modifiers: NSEvent.ModifierFlags) {
+        shortcutKey = key.lowercased()
+        shortcutModifiers = modifiers.rawValue
+    }
+
+    func clearShortcut() {
+        shortcutKey = ""
+        shortcutModifiers = 0
+    }
+
+    static func displayName(for appURL: URL) -> String {
+        let name = appURL.deletingPathExtension().lastPathComponent
+        return name.isEmpty ? "External Editor" : name
+    }
+
+    private func save() {
+        if let url = editorAppURL {
+            defaults.set(url.path, forKey: editorAppURLKey)
+        } else {
+            defaults.removeObject(forKey: editorAppURLKey)
+        }
+        defaults.set(editorDisplayName, forKey: editorDisplayNameKey)
+        defaults.set(shortcutKey, forKey: shortcutKeyKey)
+        defaults.set(shortcutModifiers, forKey: shortcutModifiersKey)
+    }
+
+    private func load() {
+        if let path = defaults.string(forKey: editorAppURLKey) {
+            editorAppURL = URL(fileURLWithPath: path)
+        }
+        if let name = defaults.string(forKey: editorDisplayNameKey) {
+            editorDisplayName = name
+        }
+        if let key = defaults.string(forKey: shortcutKeyKey), !key.isEmpty {
+            shortcutKey = key
+        }
+        if defaults.object(forKey: shortcutModifiersKey) != nil {
+            shortcutModifiers = UInt(defaults.integer(forKey: shortcutModifiersKey))
+        }
+    }
+}

--- a/MarkdownViewer/Stores/ExternalEditorSettings.swift
+++ b/MarkdownViewer/Stores/ExternalEditorSettings.swift
@@ -5,16 +5,16 @@ final class ExternalEditorSettings: ObservableObject {
     static let shared = ExternalEditorSettings()
 
     @Published var editorAppURL: URL? {
-        didSet { if !isLoading && !isBatching { save() } }
+        didSet { saveIfNeeded() }
     }
     @Published var editorDisplayName: String = "External Editor" {
-        didSet { if !isLoading && !isBatching { save() } }
+        didSet { saveIfNeeded() }
     }
     @Published var shortcutKey: String = "e" {
-        didSet { if !isLoading && !isBatching { save() } }
+        didSet { saveIfNeeded() }
     }
     @Published var shortcutModifiers: UInt = NSEvent.ModifierFlags.command.rawValue {
-        didSet { if !isLoading && !isBatching { save() } }
+        didSet { saveIfNeeded() }
     }
 
     var menuItemTitle: String {
@@ -121,6 +121,10 @@ final class ExternalEditorSettings: ObservableObject {
         return name.isEmpty ? "External Editor" : name
     }
 
+    private func saveIfNeeded() {
+        if !isLoading && !isBatching { save() }
+    }
+
     private func save() {
         guard !isLoading else { return }
         if let url = editorAppURL {
@@ -142,7 +146,7 @@ final class ExternalEditorSettings: ObservableObject {
         if let name = defaults.string(forKey: editorDisplayNameKey) {
             editorDisplayName = name
         }
-        if let key = defaults.string(forKey: shortcutKeyKey), !key.isEmpty {
+        if let key = defaults.string(forKey: shortcutKeyKey) {
             shortcutKey = key
         }
         if defaults.object(forKey: shortcutModifiersKey) != nil {

--- a/MarkdownViewer/ViewModels/DocumentState.swift
+++ b/MarkdownViewer/ViewModels/DocumentState.swift
@@ -134,6 +134,8 @@ class DocumentState: ObservableObject {
             guard let self = self else { return }
             let newModDate = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
             if newModDate != self.lastModificationDate {
+                self.lastModificationDate = newModDate
+                self.reload()
                 self.fileChanged = true
             }
         }

--- a/MarkdownViewer/ViewModels/DocumentState.swift
+++ b/MarkdownViewer/ViewModels/DocumentState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import CoreGraphics
 import Foundation
@@ -138,6 +139,9 @@ class DocumentState: ObservableObject {
                 self.lastModificationDate = newModDate
                 self.reload()
                 withAnimation(.easeInOut(duration: 0.2)) { self.fileChanged = true }
+                if UserDefaults.standard.bool(forKey: "autoRaiseOnFileChange") {
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                }
             }
         }
 

--- a/MarkdownViewer/ViewModels/DocumentState.swift
+++ b/MarkdownViewer/ViewModels/DocumentState.swift
@@ -2,6 +2,7 @@ import Combine
 import CoreGraphics
 import Foundation
 import Markdown
+import SwiftUI
 
 class DocumentState: ObservableObject {
     @Published var htmlContent: String = ""
@@ -136,7 +137,7 @@ class DocumentState: ObservableObject {
             if newModDate != self.lastModificationDate {
                 self.lastModificationDate = newModDate
                 self.reload()
-                self.fileChanged = true
+                withAnimation(.easeInOut(duration: 0.2)) { self.fileChanged = true }
             }
         }
 

--- a/MarkdownViewer/Views/ContentView.swift
+++ b/MarkdownViewer/Views/ContentView.swift
@@ -80,7 +80,9 @@ struct ContentView: View {
             }
         }
         .onExitCommand {
-            if documentState.isShowingFindBar {
+            if documentState.fileChanged {
+                documentState.fileChanged = false
+            } else if documentState.isShowingFindBar {
                 documentState.hideFindBar()
             }
         }
@@ -110,22 +112,24 @@ struct ContentView: View {
             if documentState.fileChanged || documentState.isShowingFindBar {
                 VStack(alignment: .trailing, spacing: 8) {
                     if documentState.fileChanged {
-                        Button(action: {
-                            documentState.reload()
-                        }) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "arrow.clockwise")
-                                    .font(.system(size: 11, weight: .medium))
-                                Text("File changed")
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(Color.orange.opacity(0.9))
-                            .foregroundColor(.white)
-                            .cornerRadius(6)
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .font(.system(size: 11, weight: .medium))
+                            Text("File updated")
+                                .font(.system(size: 11, weight: .medium))
+                            Text("esc to dismiss")
+                                .font(.system(size: 10))
+                                .opacity(0.7)
                         }
-                        .buttonStyle(.plain)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(Color.accentColor.opacity(0.85))
+                        .foregroundColor(.white)
+                        .cornerRadius(6)
+                        .onTapGesture {
+                            documentState.fileChanged = false
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
                     }
 
                     if documentState.isShowingFindBar {

--- a/MarkdownViewer/Views/ContentView.swift
+++ b/MarkdownViewer/Views/ContentView.swift
@@ -81,7 +81,7 @@ struct ContentView: View {
         }
         .onExitCommand {
             if documentState.fileChanged {
-                documentState.fileChanged = false
+                withAnimation(.easeInOut(duration: 0.2)) { documentState.fileChanged = false }
             } else if documentState.isShowingFindBar {
                 documentState.hideFindBar()
             }
@@ -127,7 +127,7 @@ struct ContentView: View {
                         .foregroundColor(.white)
                         .cornerRadius(6)
                         .onTapGesture {
-                            documentState.fileChanged = false
+                            withAnimation(.easeInOut(duration: 0.2)) { documentState.fileChanged = false }
                         }
                         .transition(.opacity.combined(with: .move(edge: .top)))
                     }

--- a/MarkdownViewer/Views/ContentView.swift
+++ b/MarkdownViewer/Views/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @State private var isOutlinePinned = false
     @State private var scrollRequest: ScrollRequest?
     @State private var activeAnchorID: String?
+    @ObservedObject private var appearanceSettings = AppearanceSettings.shared
 
     init(documentState: DocumentState = DocumentState()) {
         _documentState = StateObject(wrappedValue: documentState)
@@ -146,6 +147,17 @@ struct ContentView: View {
             }
         }
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: {
+                    appearanceSettings.cycle()
+                }) {
+                    Label(appearanceSettings.label, systemImage: appearanceSettings.iconName)
+                        .labelStyle(.iconOnly)
+                        .font(.system(size: 13, weight: .semibold))
+                }
+                .foregroundColor(.secondary)
+                .help(appearanceSettings.label)
+            }
             if canShowOutline {
                 ToolbarItem(placement: .primaryAction) {
                     Button(action: {

--- a/MarkdownViewer/Views/SettingsView.swift
+++ b/MarkdownViewer/Views/SettingsView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject private var settings = ExternalEditorSettings.shared
@@ -80,97 +80,6 @@ struct SettingsView: View {
     private func chooseEditor() {
         if let url = ExternalEditorSettings.presentEditorChooserPanel(message: "Select an editor application") {
             settings.setEditor(url: url)
-        }
-    }
-}
-
-struct ShortcutRecorderView: View {
-    @ObservedObject var settings: ExternalEditorSettings
-    @State private var isRecording = false
-    @State private var eventMonitor: Any?
-
-    private static let reservedKeys: Set<String> = [
-        "q", "w", "c", "v", "x", "z", "a", "o", "t", "n", "f", "s", "p", "h", "m", ","
-    ]
-
-    var body: some View {
-        HStack(spacing: 8) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isRecording
-                          ? Color.accentColor.opacity(0.1)
-                          : Color(nsColor: .controlBackgroundColor))
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(isRecording
-                                  ? Color.accentColor
-                                  : Color(nsColor: .separatorColor),
-                                  lineWidth: 1)
-
-                if isRecording {
-                    Text("Type shortcut\u{2026}")
-                        .foregroundColor(.accentColor)
-                } else if !settings.shortcutKey.isEmpty {
-                    Text(settings.shortcutDisplayString)
-                        .font(.system(.body, design: .rounded))
-                } else {
-                    Text("Click to record")
-                        .foregroundColor(.secondary)
-                }
-            }
-            .frame(width: 140, height: 24)
-            .onTapGesture {
-                if isRecording {
-                    stopRecording()
-                } else {
-                    startRecording()
-                }
-            }
-
-            if !settings.shortcutKey.isEmpty {
-                Button {
-                    settings.clearShortcut()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Remove keyboard shortcut")
-            }
-        }
-        .onDisappear {
-            stopRecording()
-        }
-    }
-
-    private func startRecording() {
-        isRecording = true
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
-            if event.keyCode == 53 { // Escape
-                stopRecording()
-                return nil
-            }
-            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if let chars = event.charactersIgnoringModifiers,
-               chars.count == 1,
-               let char = chars.first,
-               char.asciiValue.map({ $0 >= 32 && $0 < 127 }) == true {
-                // Reject reserved Cmd-only shortcuts
-                if flags == [.command] && Self.reservedKeys.contains(chars.lowercased()) {
-                    NSSound.beep()
-                    return nil
-                }
-                settings.setShortcut(key: chars, modifiers: flags)
-                stopRecording()
-            }
-            return event
-        }
-    }
-
-    private func stopRecording() {
-        isRecording = false
-        if let monitor = eventMonitor {
-            NSEvent.removeMonitor(monitor)
-            eventMonitor = nil
         }
     }
 }

--- a/MarkdownViewer/Views/SettingsView.swift
+++ b/MarkdownViewer/Views/SettingsView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import AppKit
+
+struct SettingsView: View {
+    @ObservedObject private var settings = ExternalEditorSettings.shared
+
+    var body: some View {
+        Form {
+            Section {
+                editorSection
+            } header: {
+                Text("External Editor")
+            }
+
+            Section {
+                shortcutSection
+            } header: {
+                Text("Keyboard Shortcut")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 420, height: 300)
+    }
+
+    @ViewBuilder
+    private var editorSection: some View {
+        HStack(spacing: 12) {
+            if let icon = settings.editorIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: 32, height: 32)
+            } else {
+                Image(systemName: "app.dashed")
+                    .font(.system(size: 28))
+                    .foregroundColor(.secondary)
+                    .frame(width: 32, height: 32)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                if settings.editorAppURL != nil {
+                    Text(settings.editorDisplayName)
+                        .fontWeight(.medium)
+                    Text(settings.editorAppURL?.path ?? "")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                } else {
+                    Text("No editor selected")
+                        .foregroundColor(.secondary)
+                    Text("You will be prompted to choose on first use")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+
+        HStack {
+            Button("Choose\u{2026}") {
+                chooseEditor()
+            }
+            if settings.editorAppURL != nil {
+                Button("Clear") {
+                    settings.clearEditor()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var shortcutSection: some View {
+        HStack {
+            Text("Shortcut:")
+            ShortcutRecorderView(settings: settings)
+        }
+    }
+
+    private func chooseEditor() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.message = "Select an editor application"
+        panel.prompt = "Choose"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            settings.setEditor(url: url)
+        }
+    }
+}
+
+struct ShortcutRecorderView: View {
+    @ObservedObject var settings: ExternalEditorSettings
+    @State private var isRecording = false
+    @State private var eventMonitor: Any?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isRecording
+                          ? Color.accentColor.opacity(0.1)
+                          : Color(nsColor: .controlBackgroundColor))
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(isRecording
+                                  ? Color.accentColor
+                                  : Color(nsColor: .separatorColor),
+                                  lineWidth: 1)
+
+                if isRecording {
+                    Text("Type shortcut\u{2026}")
+                        .foregroundColor(.accentColor)
+                } else if !settings.shortcutKey.isEmpty {
+                    Text(settings.shortcutDisplayString)
+                        .font(.system(.body, design: .rounded))
+                } else {
+                    Text("Click to record")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(width: 140, height: 24)
+            .onTapGesture {
+                if isRecording {
+                    stopRecording()
+                } else {
+                    startRecording()
+                }
+            }
+
+            if !settings.shortcutKey.isEmpty {
+                Button {
+                    settings.clearShortcut()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Remove keyboard shortcut")
+            }
+        }
+    }
+
+    private func startRecording() {
+        isRecording = true
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            if event.keyCode == 53 { // Escape
+                stopRecording()
+                return nil
+            }
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if let chars = event.charactersIgnoringModifiers,
+               chars.count == 1,
+               let char = chars.first,
+               char.asciiValue.map({ $0 >= 32 && $0 < 127 }) == true {
+                settings.setShortcut(key: chars, modifiers: flags)
+                stopRecording()
+            }
+            return nil
+        }
+    }
+
+    private func stopRecording() {
+        isRecording = false
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+    }
+}

--- a/MarkdownViewer/Views/ShortcutRecorderView.swift
+++ b/MarkdownViewer/Views/ShortcutRecorderView.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftUI
+
+struct ShortcutRecorderView: View {
+    @ObservedObject var settings: ExternalEditorSettings
+    @State private var isRecording = false
+    @State private var eventMonitor: Any?
+
+    private static let reservedKeys: Set<String> = [
+        "q", "w", "c", "v", "x", "z", "a", "o", "t", "n", "f", "s", "p", "h", "m", ",",
+        "r", "g", "+", "-", "0", "[", "]",
+        "1", "2", "3", "4", "5", "6", "7", "8", "9"
+    ]
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isRecording
+                          ? Color.accentColor.opacity(0.1)
+                          : Color(nsColor: .controlBackgroundColor))
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(isRecording
+                                  ? Color.accentColor
+                                  : Color(nsColor: .separatorColor),
+                                  lineWidth: 1)
+
+                if isRecording {
+                    Text("Type shortcut\u{2026}")
+                        .foregroundColor(.accentColor)
+                } else if !settings.shortcutKey.isEmpty {
+                    Text(settings.shortcutDisplayString)
+                        .font(.system(.body, design: .rounded))
+                } else {
+                    Text("Click to record")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(width: 140, height: 24)
+            .onTapGesture {
+                if isRecording {
+                    stopRecording()
+                } else {
+                    startRecording()
+                }
+            }
+
+            if !settings.shortcutKey.isEmpty {
+                Button {
+                    settings.clearShortcut()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Remove keyboard shortcut")
+            }
+        }
+        .onDisappear {
+            stopRecording()
+        }
+    }
+
+    private func startRecording() {
+        isRecording = true
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            if event.keyCode == 53 { // Escape
+                stopRecording()
+                return nil
+            }
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if let chars = event.charactersIgnoringModifiers,
+               chars.count == 1,
+               let char = chars.first,
+               char.asciiValue.map({ $0 >= 32 && $0 < 127 }) == true {
+                // Reject reserved Cmd-only shortcuts
+                if flags == [.command] && Self.reservedKeys.contains(chars.lowercased()) {
+                    NSSound.beep()
+                    return nil
+                }
+                settings.setShortcut(key: chars, modifiers: flags)
+                stopRecording()
+            }
+            return event
+        }
+    }
+
+    private func stopRecording() {
+        isRecording = false
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+    }
+}

--- a/MarkdownViewer/Views/ShortcutRecorderView.swift
+++ b/MarkdownViewer/Views/ShortcutRecorderView.swift
@@ -12,6 +12,8 @@ struct ShortcutRecorderView: View {
         "1", "2", "3", "4", "5", "6", "7", "8", "9"
     ]
 
+    private static let reservedCmdShiftKeys: Set<String> = ["[", "]", "g"]
+
     var body: some View {
         HStack(spacing: 8) {
             ZStack {
@@ -73,14 +75,19 @@ struct ShortcutRecorderView: View {
                chars.count == 1,
                let char = chars.first,
                char.asciiValue.map({ $0 >= 32 && $0 < 127 }) == true {
+                // Require at least one modifier key (Cmd, Ctrl, or Option)
+                let requiredMods: NSEvent.ModifierFlags = [.command, .control, .option]
+                guard !flags.intersection(requiredMods).isEmpty else {
+                    NSSound.beep()
+                    return nil
+                }
                 // Reject reserved Cmd-only shortcuts
                 if flags == [.command] && Self.reservedKeys.contains(chars.lowercased()) {
                     NSSound.beep()
                     return nil
                 }
                 // Reject reserved Cmd+Shift shortcuts used by the app
-                let cmdShiftReserved: Set<String> = ["[", "]", "g"]
-                if flags == [.command, .shift] && cmdShiftReserved.contains(chars.lowercased()) {
+                if flags == [.command, .shift] && Self.reservedCmdShiftKeys.contains(chars.lowercased()) {
                     NSSound.beep()
                     return nil
                 }

--- a/MarkdownViewer/Views/ShortcutRecorderView.swift
+++ b/MarkdownViewer/Views/ShortcutRecorderView.swift
@@ -78,8 +78,15 @@ struct ShortcutRecorderView: View {
                     NSSound.beep()
                     return nil
                 }
+                // Reject reserved Cmd+Shift shortcuts used by the app
+                let cmdShiftReserved: Set<String> = ["[", "]", "g"]
+                if flags == [.command, .shift] && cmdShiftReserved.contains(chars.lowercased()) {
+                    NSSound.beep()
+                    return nil
+                }
                 settings.setShortcut(key: chars, modifiers: flags)
                 stopRecording()
+                return nil
             }
             return event
         }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A native macOS Markdown viewer built with SwiftUI and WebKit.
 - Find-in-page with next/previous navigation.
 - Zoom controls (in/out/actual size).
 - Open Recent menu for quick access to files.
+- Configurable external editor with customizable keyboard shortcut (Cmd+E default).
 
 ## Build & Run
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native macOS Markdown viewer built with SwiftUI and WebKit.
 
 - Native macOS app built with SwiftUI and WebKit.
 - Tabbed windows with keyboard shortcuts.
-- File change detection with a reload prompt.
+- Auto-reload on file change with dismissable notification.
 - Mermaid diagram rendering.
 - Table of contents sidebar (pinnable or hover to reveal).
 - Syntax highlighting for fenced code blocks.
@@ -16,7 +16,26 @@ A native macOS Markdown viewer built with SwiftUI and WebKit.
 - Find-in-page with next/previous navigation.
 - Zoom controls (in/out/actual size).
 - Open Recent menu for quick access to files.
-- Configurable external editor with customizable keyboard shortcut (Cmd+E default).
+- Configurable external editor with customizable keyboard shortcut.
+- Optional bring-to-front when a file is modified externally.
+
+## External Editor
+
+Open the current file in your preferred editor directly from the viewer. Configure the editor and keyboard shortcut in Settings (Cmd+,).
+
+- **Default shortcut:** Cmd+E
+- **Supported editors:** Any application that accepts file URLs (Sublime Text, VS Code, BBEdit, etc.)
+- **Setup:** Settings > External Editor > Choose, then select an app from /Applications
+- **Custom shortcut:** Settings > Keyboard Shortcut — click the recorder and press your desired key combination
+
+If no editor is configured, the first use will prompt you to select one.
+
+## Bring to Front on File Change
+
+When enabled, the viewer window automatically comes to front whenever the monitored file is modified externally. Useful when editing in a separate application and wanting the preview to surface after each save.
+
+- **Toggle:** View > Bring to Front on File Change
+- **Default:** Off
 
 ## Build & Run
 

--- a/Tests/MarkdownViewerTests/DocumentStateTests.swift
+++ b/Tests/MarkdownViewerTests/DocumentStateTests.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import MarkdownViewer
+
+final class DocumentStateTests: XCTestCase {
+
+    // MARK: - loadFile
+
+    func testLoadFileSetsHTMLContentAndTitle() throws {
+        let file = try TemporaryFile.create(named: "test.md")
+        defer { file.cleanup() }
+        try "# Hello\nWorld".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+
+        XCTAssertTrue(state.htmlContent.contains("Hello"))
+        XCTAssertTrue(state.htmlContent.contains("World"))
+        XCTAssertEqual(state.title, "test.md")
+        XCTAssertEqual(state.currentURL, file.url)
+    }
+
+    func testLoadFileResetsFileChangedFlag() throws {
+        let file = try TemporaryFile.create(named: "note.md")
+        defer { file.cleanup() }
+        try "# Note".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.fileChanged = true
+        state.loadFile(at: file.url)
+
+        XCTAssertFalse(state.fileChanged)
+    }
+
+    func testLoadFileParsesOutlineItems() throws {
+        let file = try TemporaryFile.create(named: "outline.md")
+        defer { file.cleanup() }
+        try "# Title\n## Section One\n## Section Two".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+
+        // normalizedOutline drops the single H1 and shifts levels
+        XCTAssertEqual(state.outlineItems.count, 2)
+        XCTAssertEqual(state.outlineItems[0].title, "Section One")
+        XCTAssertEqual(state.outlineItems[1].title, "Section Two")
+    }
+
+    func testLoadFileWithFrontMatterIncludesMetadataInHTML() throws {
+        let file = try TemporaryFile.create(named: "meta.md")
+        defer { file.cleanup() }
+        try "---\ntitle: My Doc\nauthor: Test\n---\n# Content".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+
+        XCTAssertTrue(state.htmlContent.contains("My Doc"))
+        XCTAssertTrue(state.htmlContent.contains("Author"))
+        XCTAssertTrue(state.htmlContent.contains("front-matter"))
+    }
+
+    func testLoadFileWithInvalidPathSetsErrorContent() {
+        let badURL = URL(fileURLWithPath: "/nonexistent/path/file.md")
+        let state = DocumentState()
+        state.loadFile(at: badURL)
+
+        XCTAssertTrue(state.htmlContent.contains("Error loading file"))
+        XCTAssertEqual(state.title, "Error")
+        XCTAssertTrue(state.outlineItems.isEmpty)
+    }
+
+    func testLoadFileEscapesHTMLInFrontMatter() throws {
+        let file = try TemporaryFile.create(named: "escape.md")
+        defer { file.cleanup() }
+        try "---\ntitle: <script>alert('xss')</script>\n---\n# Safe".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+
+        XCTAssertTrue(state.htmlContent.contains("&lt;script&gt;"))
+        XCTAssertFalse(state.htmlContent.contains("<script>alert"))
+    }
+
+    // MARK: - reload
+
+    func testReloadSetsNewReloadToken() throws {
+        let file = try TemporaryFile.create(named: "reload.md")
+        defer { file.cleanup() }
+        try "# Reload Me".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+        let tokenBefore = state.reloadToken
+
+        state.reload()
+
+        XCTAssertNotNil(state.reloadToken)
+        XCTAssertNotEqual(state.reloadToken, tokenBefore)
+    }
+
+    func testReloadWithoutCurrentURLIsNoOp() {
+        let state = DocumentState()
+        let tokenBefore = state.reloadToken
+
+        state.reload()
+
+        XCTAssertEqual(state.reloadToken, tokenBefore)
+    }
+
+    func testReloadReflectsUpdatedFileContent() throws {
+        let file = try TemporaryFile.create(named: "changing.md")
+        defer { file.cleanup() }
+        try "# Version 1".write(to: file.url, atomically: true, encoding: .utf8)
+
+        let state = DocumentState()
+        state.loadFile(at: file.url)
+        XCTAssertTrue(state.htmlContent.contains("Version 1"))
+
+        try "# Version 2".write(to: file.url, atomically: true, encoding: .utf8)
+        state.reload()
+
+        XCTAssertTrue(state.htmlContent.contains("Version 2"))
+        XCTAssertFalse(state.htmlContent.contains("Version 1"))
+    }
+
+    // MARK: - Zoom
+
+    func testZoomInIncreasesLevel() {
+        let state = DocumentState()
+        XCTAssertEqual(state.zoomLevel, 1.0)
+
+        state.zoomIn()
+
+        XCTAssertEqual(state.zoomLevel, 1.1, accuracy: 0.001)
+    }
+
+    func testZoomOutDecreasesLevel() {
+        let state = DocumentState()
+
+        state.zoomOut()
+
+        XCTAssertEqual(state.zoomLevel, 0.9, accuracy: 0.001)
+    }
+
+    func testZoomInClampsAtMaximum() {
+        let state = DocumentState()
+        state.zoomLevel = 2.95
+
+        state.zoomIn()
+
+        XCTAssertEqual(state.zoomLevel, 3.0, accuracy: 0.001)
+
+        state.zoomIn()
+
+        XCTAssertEqual(state.zoomLevel, 3.0, accuracy: 0.001)
+    }
+
+    func testZoomOutClampsAtMinimum() {
+        let state = DocumentState()
+        state.zoomLevel = 0.55
+
+        state.zoomOut()
+
+        XCTAssertEqual(state.zoomLevel, 0.5, accuracy: 0.001)
+
+        state.zoomOut()
+
+        XCTAssertEqual(state.zoomLevel, 0.5, accuracy: 0.001)
+    }
+
+    func testResetZoomRestoresToDefault() {
+        let state = DocumentState()
+        state.zoomIn()
+        state.zoomIn()
+
+        state.resetZoom()
+
+        XCTAssertEqual(state.zoomLevel, 1.0)
+    }
+
+    // MARK: - Find Bar
+
+    func testShowFindBarSetsIsShowing() {
+        let state = DocumentState()
+        XCTAssertFalse(state.isShowingFindBar)
+
+        state.showFindBar()
+
+        XCTAssertTrue(state.isShowingFindBar)
+    }
+
+    func testShowFindBarUpdatesFocusToken() {
+        let state = DocumentState()
+        let tokenBefore = state.findFocusToken
+
+        state.showFindBar()
+
+        XCTAssertNotEqual(state.findFocusToken, tokenBefore)
+    }
+
+    func testHideFindBarClearsShowingAndSendsClearRequest() {
+        let state = DocumentState()
+        state.showFindBar()
+        state.findQuery = "search"
+        state.findNext()  // sets findRequest to non-empty query
+        let requestBeforeHide = state.findRequest
+        XCTAssertEqual(requestBeforeHide?.query, "search")
+
+        state.hideFindBar()
+
+        XCTAssertFalse(state.isShowingFindBar)
+        XCTAssertNotNil(state.findRequest)
+        XCTAssertEqual(state.findRequest?.query, "")
+        // The token should differ from before, proving hideFindBar issued a new request
+        XCTAssertNotEqual(state.findRequest?.token, requestBeforeHide?.token)
+    }
+
+    func testUpdateFindResultsTrimsWhitespaceAndSetsRequest() {
+        let state = DocumentState()
+        state.findQuery = "  hello  "
+
+        state.updateFindResults()
+
+        XCTAssertEqual(state.findRequest?.query, "hello")
+        XCTAssertEqual(state.findRequest?.direction, .forward)
+        XCTAssertTrue(state.findRequest?.reset ?? false)
+    }
+
+    func testUpdateFindResultsWithEmptyQuerySendsClearRequest() {
+        let state = DocumentState()
+        state.findQuery = "   "
+
+        state.updateFindResults()
+
+        XCTAssertEqual(state.findRequest?.query, "")
+        XCTAssertEqual(state.findRequest?.direction, .forward)
+        XCTAssertTrue(state.findRequest?.reset ?? false)
+    }
+
+    func testFindNextSetsForwardDirection() {
+        let state = DocumentState()
+        state.findQuery = "term"
+
+        state.findNext()
+
+        XCTAssertEqual(state.findRequest?.query, "term")
+        XCTAssertEqual(state.findRequest?.direction, .forward)
+        XCTAssertFalse(state.findRequest?.reset ?? true)
+    }
+
+    func testFindPreviousSetsBackwardDirection() {
+        let state = DocumentState()
+        state.findQuery = "term"
+
+        state.findPrevious()
+
+        XCTAssertEqual(state.findRequest?.query, "term")
+        XCTAssertEqual(state.findRequest?.direction, .backward)
+        XCTAssertFalse(state.findRequest?.reset ?? true)
+    }
+
+    func testFindNextWithEmptyQuerySendsClearRequest() {
+        let state = DocumentState()
+        state.findQuery = ""
+
+        state.findNext()
+
+        XCTAssertEqual(state.findRequest?.query, "")
+    }
+}

--- a/Tests/MarkdownViewerTests/EscapeDismissalTests.swift
+++ b/Tests/MarkdownViewerTests/EscapeDismissalTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import MarkdownViewer
+
+/// Tests for the Escape key dismissal priority logic from ContentView.
+///
+/// ContentView's .onExitCommand handler uses a priority chain:
+/// 1. If fileChanged is true, dismiss the notification (set fileChanged = false)
+/// 2. Otherwise, if the find bar is showing, hide it
+///
+/// Since ContentView depends on SwiftUI framework bindings and cannot be
+/// render-tested in a unit test environment, we use behavioral extraction
+/// to test the decision logic directly.
+final class EscapeDismissalTests: XCTestCase {
+
+    /// Mirrors the .onExitCommand handler in ContentView.swift (line 82-88).
+    /// Returns a description of the action taken for assertion purposes.
+    private enum EscapeAction: Equatable {
+        case dismissedNotification
+        case closedFindBar
+        case noAction
+    }
+
+    /// Mirrors ContentView.onExitCommand logic.
+    /// Mutates state the same way the real handler does.
+    private func simulateEscapeKey(on state: DocumentState) -> EscapeAction {
+        if state.fileChanged {
+            state.fileChanged = false
+            return .dismissedNotification
+        } else if state.isShowingFindBar {
+            state.hideFindBar()
+            return .closedFindBar
+        }
+        return .noAction
+    }
+
+    func testEscapeDismissesNotificationBeforeFindBar() {
+        let state = DocumentState()
+        state.fileChanged = true
+        state.showFindBar()
+
+        let action = simulateEscapeKey(on: state)
+
+        XCTAssertEqual(action, .dismissedNotification)
+        XCTAssertFalse(state.fileChanged)
+        // Find bar should still be open because notification took priority
+        XCTAssertTrue(state.isShowingFindBar)
+    }
+
+    func testEscapeClosesFindBarWhenNoNotification() {
+        let state = DocumentState()
+        state.fileChanged = false
+        state.showFindBar()
+
+        let action = simulateEscapeKey(on: state)
+
+        XCTAssertEqual(action, .closedFindBar)
+        XCTAssertFalse(state.isShowingFindBar)
+    }
+
+    func testEscapeDoesNothingWhenNothingActive() {
+        let state = DocumentState()
+        state.fileChanged = false
+
+        let action = simulateEscapeKey(on: state)
+
+        XCTAssertEqual(action, .noAction)
+    }
+
+    func testConsecutiveEscapesDismissNotificationThenFindBar() {
+        let state = DocumentState()
+        state.fileChanged = true
+        state.showFindBar()
+
+        let firstAction = simulateEscapeKey(on: state)
+        XCTAssertEqual(firstAction, .dismissedNotification)
+        XCTAssertTrue(state.isShowingFindBar)
+
+        let secondAction = simulateEscapeKey(on: state)
+        XCTAssertEqual(secondAction, .closedFindBar)
+        XCTAssertFalse(state.isShowingFindBar)
+    }
+
+    func testEscapeOnlyDismissesNotificationWhenFindBarNotShowing() {
+        let state = DocumentState()
+        state.fileChanged = true
+
+        let action = simulateEscapeKey(on: state)
+
+        XCTAssertEqual(action, .dismissedNotification)
+        XCTAssertFalse(state.fileChanged)
+    }
+}

--- a/Tests/MarkdownViewerTests/ExternalEditorSettingsTests.swift
+++ b/Tests/MarkdownViewerTests/ExternalEditorSettingsTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+@testable import MarkdownViewer
+
+final class ExternalEditorSettingsTests: XCTestCase {
+
+    // MARK: - UserDefaults backup/restore for test isolation
+
+    private let editorAppURLKey = "externalEditorAppURL"
+    private let editorDisplayNameKey = "externalEditorDisplayName"
+    private let shortcutKeyKey = "externalEditorShortcutKey"
+    private let shortcutModifiersKey = "externalEditorShortcutModifiers"
+
+    private var savedEditorAppURL: Any?
+    private var savedEditorDisplayName: Any?
+    private var savedShortcutKey: Any?
+    private var savedShortcutModifiers: Any?
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        savedEditorAppURL = defaults.object(forKey: editorAppURLKey)
+        savedEditorDisplayName = defaults.object(forKey: editorDisplayNameKey)
+        savedShortcutKey = defaults.object(forKey: shortcutKeyKey)
+        savedShortcutModifiers = defaults.object(forKey: shortcutModifiersKey)
+
+        // Clear state so each test starts fresh
+        defaults.removeObject(forKey: editorAppURLKey)
+        defaults.removeObject(forKey: editorDisplayNameKey)
+        defaults.removeObject(forKey: shortcutKeyKey)
+        defaults.removeObject(forKey: shortcutModifiersKey)
+
+        let settings = ExternalEditorSettings.shared
+        settings.clearEditor()
+        settings.clearShortcut()
+        // Restore default shortcut key to "e" with Cmd, matching the class defaults
+        settings.setShortcut(key: "e", modifiers: .command)
+    }
+
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        restoreDefault(defaults, key: editorAppURLKey, value: savedEditorAppURL)
+        restoreDefault(defaults, key: editorDisplayNameKey, value: savedEditorDisplayName)
+        restoreDefault(defaults, key: shortcutKeyKey, value: savedShortcutKey)
+        restoreDefault(defaults, key: shortcutModifiersKey, value: savedShortcutModifiers)
+        super.tearDown()
+    }
+
+    private func restoreDefault(_ defaults: UserDefaults, key: String, value: Any?) {
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    // MARK: - displayName(for:) tests
+
+    func testDisplayNameForStandardApp() {
+        let url = URL(fileURLWithPath: "/Applications/Sublime Text.app")
+        XCTAssertEqual(ExternalEditorSettings.displayName(for: url), "Sublime Text")
+    }
+
+    func testDisplayNameForSingleWordApp() {
+        let url = URL(fileURLWithPath: "/Applications/TextEdit.app")
+        XCTAssertEqual(ExternalEditorSettings.displayName(for: url), "TextEdit")
+    }
+
+    func testDisplayNameForNestedApp() {
+        let url = URL(fileURLWithPath: "/Applications/Utilities/Terminal.app")
+        XCTAssertEqual(ExternalEditorSettings.displayName(for: url), "Terminal")
+    }
+
+    func testDisplayNameForPathWithoutExtension() {
+        let url = URL(fileURLWithPath: "/usr/local/bin/vim")
+        XCTAssertEqual(ExternalEditorSettings.displayName(for: url), "vim")
+    }
+
+    func testDisplayNameForRootURL() {
+        // URL(fileURLWithPath: "/") has an empty lastPathComponent after removing extension
+        let url = URL(fileURLWithPath: "/")
+        let name = ExternalEditorSettings.displayName(for: url)
+        // The lastPathComponent of "/" is "/", deleting path extension still gives "/"
+        // so name should not be empty
+        XCTAssertFalse(name.isEmpty)
+    }
+
+    // MARK: - shortcutDisplayString tests
+
+    func testShortcutDisplayStringCommandOnly() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        XCTAssertEqual(settings.shortcutDisplayString, "\u{2318}E")
+    }
+
+    func testShortcutDisplayStringCommandShift() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "o", modifiers: [.command, .shift])
+        XCTAssertEqual(settings.shortcutDisplayString, "\u{21E7}\u{2318}O")
+    }
+
+    func testShortcutDisplayStringAllModifiers() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "x", modifiers: [.control, .option, .shift, .command])
+        XCTAssertEqual(settings.shortcutDisplayString, "\u{2303}\u{2325}\u{21E7}\u{2318}X")
+    }
+
+    func testShortcutDisplayStringNoModifiers() {
+        let settings = ExternalEditorSettings.shared
+        settings.shortcutKey = "f"
+        settings.shortcutModifiers = 0
+        XCTAssertEqual(settings.shortcutDisplayString, "F")
+    }
+
+    func testShortcutDisplayStringOptionCommand() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "t", modifiers: [.option, .command])
+        XCTAssertEqual(settings.shortcutDisplayString, "\u{2325}\u{2318}T")
+    }
+
+    func testShortcutDisplayStringControlOnly() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "c", modifiers: .control)
+        XCTAssertEqual(settings.shortcutDisplayString, "\u{2303}C")
+    }
+
+    // MARK: - menuItemTitle tests
+
+    func testMenuItemTitleWithNoEditor() {
+        let settings = ExternalEditorSettings.shared
+        settings.clearEditor()
+        XCTAssertEqual(settings.menuItemTitle, "Open in External Editor")
+    }
+
+    func testMenuItemTitleWithEditorConfigured() {
+        let settings = ExternalEditorSettings.shared
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/Sublime Text.app"))
+        XCTAssertEqual(settings.menuItemTitle, "Open in Sublime Text")
+    }
+
+    func testMenuItemTitleUpdatesAfterEditorChange() {
+        let settings = ExternalEditorSettings.shared
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/TextEdit.app"))
+        XCTAssertEqual(settings.menuItemTitle, "Open in TextEdit")
+
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/Visual Studio Code.app"))
+        XCTAssertEqual(settings.menuItemTitle, "Open in Visual Studio Code")
+    }
+
+    func testMenuItemTitleAfterClearEditor() {
+        let settings = ExternalEditorSettings.shared
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/Sublime Text.app"))
+        settings.clearEditor()
+        XCTAssertEqual(settings.menuItemTitle, "Open in External Editor")
+    }
+
+    // MARK: - keyboardShortcut tests
+
+    func testKeyboardShortcutIsNotNilWithValidKey() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        XCTAssertNotNil(settings.keyboardShortcut)
+    }
+
+    func testKeyboardShortcutIsNilWhenKeyEmpty() {
+        let settings = ExternalEditorSettings.shared
+        settings.clearShortcut()
+        XCTAssertNil(settings.keyboardShortcut)
+    }
+
+    // MARK: - setShortcut / clearShortcut tests
+
+    func testSetShortcutUpdatesKeyAndModifiers() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "T", modifiers: [.command, .shift])
+        XCTAssertEqual(settings.shortcutKey, "t")  // lowercased
+        XCTAssertEqual(settings.shortcutModifiers, NSEvent.ModifierFlags([.command, .shift]).rawValue)
+    }
+
+    func testSetShortcutLowercasesKey() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "Z", modifiers: .command)
+        XCTAssertEqual(settings.shortcutKey, "z")
+    }
+
+    func testClearShortcutResetsKeyAndModifiers() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        settings.clearShortcut()
+        XCTAssertEqual(settings.shortcutKey, "")
+        XCTAssertEqual(settings.shortcutModifiers, 0)
+    }
+
+    // MARK: - setEditor / clearEditor tests
+
+    func testSetEditorUpdatesURLAndDisplayName() {
+        let settings = ExternalEditorSettings.shared
+        let url = URL(fileURLWithPath: "/Applications/Sublime Text.app")
+        settings.setEditor(url: url)
+        XCTAssertEqual(settings.editorAppURL, url)
+        XCTAssertEqual(settings.editorDisplayName, "Sublime Text")
+    }
+
+    func testClearEditorResetsURLAndDisplayName() {
+        let settings = ExternalEditorSettings.shared
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/TextEdit.app"))
+        settings.clearEditor()
+        XCTAssertNil(settings.editorAppURL)
+        XCTAssertEqual(settings.editorDisplayName, "External Editor")
+    }
+
+    func testSetEditorMultipleTimes() {
+        let settings = ExternalEditorSettings.shared
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/TextEdit.app"))
+        XCTAssertEqual(settings.editorDisplayName, "TextEdit")
+
+        settings.setEditor(url: URL(fileURLWithPath: "/Applications/Nova.app"))
+        XCTAssertEqual(settings.editorDisplayName, "Nova")
+        XCTAssertEqual(settings.editorAppURL, URL(fileURLWithPath: "/Applications/Nova.app"))
+    }
+
+    // MARK: - shortcutIdentity tests
+
+    func testShortcutIdentityFormat() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        let expected = "e-\(NSEvent.ModifierFlags.command.rawValue)"
+        XCTAssertEqual(settings.shortcutIdentity, expected)
+    }
+
+    func testShortcutIdentityChangesWhenKeyChanges() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        let identity1 = settings.shortcutIdentity
+
+        settings.setShortcut(key: "o", modifiers: .command)
+        let identity2 = settings.shortcutIdentity
+
+        XCTAssertNotEqual(identity1, identity2)
+    }
+
+    func testShortcutIdentityChangesWhenModifiersChange() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        let identity1 = settings.shortcutIdentity
+
+        settings.setShortcut(key: "e", modifiers: [.command, .shift])
+        let identity2 = settings.shortcutIdentity
+
+        XCTAssertNotEqual(identity1, identity2)
+    }
+
+    func testShortcutIdentityStableWhenUnchanged() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        let identity1 = settings.shortcutIdentity
+        let identity2 = settings.shortcutIdentity
+        XCTAssertEqual(identity1, identity2)
+    }
+
+    func testShortcutIdentityAfterClear() {
+        let settings = ExternalEditorSettings.shared
+        settings.setShortcut(key: "e", modifiers: .command)
+        let identityBefore = settings.shortcutIdentity
+
+        settings.clearShortcut()
+        let identityAfter = settings.shortcutIdentity
+
+        XCTAssertNotEqual(identityBefore, identityAfter)
+        XCTAssertEqual(identityAfter, "-0")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a cycling appearance toggle (System → Light → Dark) accessible via a toolbar icon in the window title bar and a View menu item (Cmd+Shift+L)
- Icons update to reflect current mode: half-circle (system), sun (light), moon (dark)
- Preference persists across launches via UserDefaults
- Works by overriding `NSApp.appearance`, which cascades to the WebView's CSS `prefers-color-scheme` media query — no CSS changes needed

## Test plan
- [ ] Launch app and verify the appearance toggle icon appears in the toolbar (left of the TOC button)
- [ ] Click the icon and verify it cycles: System → Light → Dark → System
- [ ] Verify the rendered markdown switches between light and dark themes
- [ ] Verify Cmd+Shift+L toggles appearance from the View menu
- [ ] Quit and relaunch — verify the appearance preference persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)